### PR TITLE
Default to showing the latest block if no height provided

### DIFF
--- a/index.php
+++ b/index.php
@@ -17,8 +17,17 @@
 	elseif (isset ($_REQUEST["block_height"]))
 	{
 		site_header ("Block Detail Page");
+
+		$block_height = $_REQUEST["block_height"];
+
+		if(empty ($block_height))
+		{
+			$network_info = getinfo ();
+			// Default to the latest block
+			$block_height = intval($network_info["blocks"]);
+		}
 		
-		block_detail ($_REQUEST["block_height"]);
+		block_detail ($block_height);
 	}
 	
 //	If a TXid was provided the TX Detail is shown


### PR DESCRIPTION
#### What's New

If no value is entered in the "Block Height" input field, default to grabbing data for the latest block.
#### Issues
- It may not be the most efficient idea to call `getinfo();` but it still shouldn't be called more than once on page-load, so this isn't really an issue anyway. Just raising this so we can tidy/move this code later if we need to.
